### PR TITLE
fix: 将强制链接的依赖放到最前面，避免接口实现在先于强制链接链接导致符号丢失

### DIFF
--- a/target/details/__aoe_add_target.cmake
+++ b/target/details/__aoe_add_target.cmake
@@ -153,7 +153,7 @@ macro(__aoe_add_target type)
     __aoe_target_property(${target} DEPENDENCIES SET ${config_DEPEND} ${config_PRIVATE_DEPEND} ${config_FORCE_DEPEND})
 
     # Set the build order dependencies
-    set(build_depends ${config_DEPEND} ${config_PRIVATE_DEPEND} ${config_FORCE_DEPEND} ${config_BUILD_DEPEND})
+    set(build_depends ${config_DEPEND} ${config_FORCE_DEPEND} ${config_PRIVATE_DEPEND} ${config_BUILD_DEPEND})
 
     if (NOT "${build_depends}" STREQUAL "")
         add_dependencies(${target} ${build_depends})


### PR DESCRIPTION
yankai fix it！